### PR TITLE
adding chain guard and ci/cd

### DIFF
--- a/.github/workflows/atolio-build-publish.yml
+++ b/.github/workflows/atolio-build-publish.yml
@@ -19,8 +19,7 @@ env:
   MULTI_ARCH: true
   AWS_REGION: us-west-2
   ECR_REPOSITORY: ${{ github.event.repository.name }}
-  # DOCKER_ID: atolio
-  AWS_ACCOUNT_ID: 336003673347
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
 
 jobs:
   build:
@@ -70,7 +69,6 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           MULTI_ARCH: ${{ env.MULTI_ARCH }}
-          # DOCKER_ID: ${{ env.DOCKER_ID }}
           PROJECT_NAME: ${{ env.PROJECT_NAME }}
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           AWS_ACCOUNT_ID: ${{ env.AWS_ACCOUNT_ID }}
@@ -79,11 +77,10 @@ jobs:
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
           # Set final tag, prioritizing manual input, then short SHA
           RELEASE_IMAGE_TAG="${{ inputs.version }}"
-          if [ -z "$FINAL_TAG" ]; then
+          if [ -z "$RELEASE_IMAGE_TAG" ]; then
             RELEASE_IMAGE_TAG="$SHORT_SHA"
           fi          
           
-          mvn clean package
-          # Tag and push the image built by Maven
-          # docker tag ${{ env.DOCKER_ID }}/${{ env.PROJECT_NAME }}:$RELEASE_IMAGE_TAG $REGISTRY/${{ env.ECR_REPOSITORY }}:$FINAL_TAG
-          # docker push $REGISTRY/${{ env.ECR_REPOSITORY }}:$FINAL_TAG 
+          export RELEASE_IMAGE_TAG="${RELEASE_IMAGE_TAG}"
+          
+          mvn clean package 

--- a/.github/workflows/atolio-build-publish.yml
+++ b/.github/workflows/atolio-build-publish.yml
@@ -1,0 +1,80 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  PROJECT_NAME: tika-pipes
+  MULTI_ARCH: true
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: ${{ github.event.repository.name }}
+  DOCKER_ID: bfirestone
+
+jobs:
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+          cache: 'maven'
+
+      - name: Configure AWS credentials
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        if: github.event_name != 'pull_request'
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+
+      - name: Build with Maven and Package Docker Image
+        env:
+          MULTI_ARCH: ${{ env.MULTI_ARCH }}
+          DOCKER_ID: ${{ env.DOCKER_ID }}
+          PROJECT_NAME: ${{ env.PROJECT_NAME }}
+          RELEASE_IMAGE_TAG: ${{ steps.meta.outputs.version || 'latest' }}
+        run: mvn clean package
+
+      - name: Build and push Docker image
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: tika-pipes-grpc/docker-build
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max 

--- a/.github/workflows/atolio-build-publish.yml
+++ b/.github/workflows/atolio-build-publish.yml
@@ -7,13 +7,20 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Docker image version tag'
+        required: true
+        type: string
 
 env:
   PROJECT_NAME: tika-pipes
   MULTI_ARCH: true
-  AWS_REGION: us-east-1
+  AWS_REGION: us-west-2
   ECR_REPOSITORY: ${{ github.event.repository.name }}
-  DOCKER_ID: bfirestone
+  # DOCKER_ID: atolio
+  AWS_ACCOUNT_ID: 336003673347
 
 jobs:
   build:
@@ -26,6 +33,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Debug GitHub Context
+        run: |
+          echo "Repository: ${{ github.repository }}"
+          echo "Actor: ${{ github.actor }}"
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "SHA: ${{ github.sha }}"
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -36,45 +51,39 @@ jobs:
       - name: Configure AWS credentials
         if: github.event_name != 'pull_request'
         uses: aws-actions/configure-aws-credentials@v4
+        env:
+          ACTIONS_STEP_DEBUG: true
+          ACTIONS_RUNNER_DEBUG: true
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: false
+          role-duration-seconds: 900
+          output-credentials: true
 
       - name: Login to Amazon ECR
         if: github.event_name != 'pull_request'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,format=long
-
-      - name: Build with Maven and Package Docker Image
+      - name: Build with Maven and Push Docker Image
+        if: github.event_name != 'pull_request'
         env:
           MULTI_ARCH: ${{ env.MULTI_ARCH }}
-          DOCKER_ID: ${{ env.DOCKER_ID }}
+          # DOCKER_ID: ${{ env.DOCKER_ID }}
           PROJECT_NAME: ${{ env.PROJECT_NAME }}
-          RELEASE_IMAGE_TAG: ${{ steps.meta.outputs.version || 'latest' }}
-        run: mvn clean package
-
-      - name: Build and push Docker image
-        if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
-        with:
-          context: tika-pipes-grpc/docker-build
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max 
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          AWS_ACCOUNT_ID: ${{ env.AWS_ACCOUNT_ID }}
+        run: |
+          # Get short SHA for tag
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          # Set final tag, prioritizing manual input, then short SHA
+          RELEASE_IMAGE_TAG="${{ inputs.version }}"
+          if [ -z "$FINAL_TAG" ]; then
+            RELEASE_IMAGE_TAG="$SHORT_SHA"
+          fi          
+          
+          mvn clean package
+          # Tag and push the image built by Maven
+          # docker tag ${{ env.DOCKER_ID }}/${{ env.PROJECT_NAME }}:$RELEASE_IMAGE_TAG $REGISTRY/${{ env.ECR_REPOSITORY }}:$FINAL_TAG
+          # docker push $REGISTRY/${{ env.ECR_REPOSITORY }}:$FINAL_TAG 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <name>Tika Pipes Parent</name>
   <description>Tika Pipes Parent Pom</description>
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <pf4j.version>3.12.0</pf4j.version>
     <commons.io.version>2.16.1</commons.io.version>
     <commons.lang3.version>3.16.0</commons.lang3.version>

--- a/tika-pipes-grpc/docker-build/Dockerfile
+++ b/tika-pipes-grpc/docker-build/Dockerfile
@@ -1,33 +1,20 @@
-FROM ubuntu:latest
+FROM cgr.dev/chainguard/jdk:latest-dev
 COPY libs/ /tika/libs/
 COPY plugins/ /tika/plugins/
 COPY config/ /tika/config/
 COPY bin/ /tika/bin
-ARG JRE='openjdk-17-jre-headless'
 ARG VERSION='3.0.0-beta1'
-RUN set -eux \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg2 software-properties-common \
-    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends $JRE \
-        gdal-bin \
-        tesseract-ocr \
-        tesseract-ocr-eng \
-        tesseract-ocr-ita \
-        tesseract-ocr-fra \
-        tesseract-ocr-spa \
-        tesseract-ocr-deu \
-    && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-        xfonts-utils \
-        fonts-freefont-ttf \
-        fonts-liberation \
-        ttf-mscorefonts-installer \
+
+USER root
+
+RUN apk update && \
+    apk add gdal \
         wget \
-        cabextract \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	cabextract
 
 EXPOSE 50051
 ENV TIKA_PIPES_VERSION=$VERSION
 RUN chmod +x "/tika/bin/start-tika-grpc.sh"
-ENTRYPOINT ["/tika/bin/start-tika-grpc.sh"]
+
+RUN chown -R java:java /tika
+#ENTRYPOINT ["/tika/bin/start-tika-grpc.sh"]

--- a/tika-pipes-grpc/docker-build/docker-build.sh
+++ b/tika-pipes-grpc/docker-build/docker-build.sh
@@ -95,7 +95,17 @@ if [ ${#IMAGE_TAGS[@]} -eq 0 ]; then
     exit 0
 fi
 
+echo " ==================================================================================================="
+echo "MULTI_ARCH: ${MULTI_ARCH}"
+echo "DOCKER_ID: ${DOCKER_ID}"
+echo "PROJECT_NAME: ${PROJECT_NAME}"
+echo "RELEASE_IMAGE_TAG: ${RELEASE_IMAGE_TAG}"
+echo "REGISTRY: ${REGISTRY}"
+
 tag="${IMAGE_TAGS[*]}"
+echo "IMAGE_TAG: ${tag}"
+echo " ==================================================================================================="
+
 if [ "${MULTI_ARCH}" == "true" ]; then
   echo "Building multi arch image"
   docker buildx create --name tikapipesbuilder

--- a/tika-pipes-grpc/pom.xml
+++ b/tika-pipes-grpc/pom.xml
@@ -14,7 +14,7 @@
     running parsers on files in a platform independent and efficient way using HTTP2.
   </description>
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <grpc.version>1.60.0</grpc.version>
     <protobuf.version>3.24.0</protobuf.version>
     <protoc.version>3.24.0</protoc.version>


### PR DESCRIPTION
This PR adds chain guard support and CI/CD to Tika by:

* change `Dockerfile`  to use latest jdk of chain guard
* updating the `pom.xml` for jdk v21 support
* adding initial github workflow