### PR TITLE
[ENG 6952] Make handler type configurable

### DIFF
--- a/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/parser/ParseService.java
+++ b/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/parser/ParseService.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component
@@ -84,10 +85,15 @@ public class ParseService {
     }
 
     private RecursiveParserWrapperHandler getRecursiveParserWrapperHandler(ParseContext context, TikaConfig tikaConfig) {
-        HandlerConfig handlerConfig = new HandlerConfig(BasicContentHandlerFactory.HANDLER_TYPE.TEXT, HandlerConfig.PARSE_MODE.RMETA, writeLimit, maxEmbeddedResources, throwOnWriteLimitReached);
+        HandlerConfig handlerConfig = new HandlerConfig(getHandlerType(context), HandlerConfig.PARSE_MODE.RMETA, writeLimit, maxEmbeddedResources, throwOnWriteLimitReached);
         BasicContentHandlerFactory.HANDLER_TYPE type = handlerConfig.getType();
         BasicContentHandlerFactory contentHandlerFactory = new BasicContentHandlerFactory(type, handlerConfig.getWriteLimit(), handlerConfig.isThrowOnWriteLimitReached(), context);
         return new RecursiveParserWrapperHandler(contentHandlerFactory, handlerConfig.getMaxEmbeddedResources(), tikaConfig.getMetadataFilter());
+    }
+
+    private BasicContentHandlerFactory.HANDLER_TYPE getHandlerType(ParseContext parseContext) {
+        BasicContentHandlerFactory.HANDLER_TYPE hType = parseContext.get(BasicContentHandlerFactory.HANDLER_TYPE.class);
+        return Objects.requireNonNullElse(hType, BasicContentHandlerFactory.HANDLER_TYPE.TEXT);
     }
 
     /**

--- a/tika-pipes-grpc/src/main/java/org/apache/tika/pipes/grpc/TikaGrpcService.java
+++ b/tika-pipes-grpc/src/main/java/org/apache/tika/pipes/grpc/TikaGrpcService.java
@@ -74,6 +74,7 @@ import org.apache.tika.pipes.repo.EmitterRepository;
 import org.apache.tika.pipes.repo.FetcherRepository;
 import org.apache.tika.pipes.repo.JobStatusRepository;
 import org.apache.tika.pipes.repo.PipeIteratorRepository;
+import org.apache.tika.sax.BasicContentHandlerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.pf4j.PluginManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,6 +100,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @GrpcService
 public class TikaGrpcService extends TikaGrpc.TikaImplBase {
     private final ExecutorService executorService = Executors.newCachedThreadPool(new TikaRunnerThreadFactory());
+    private static final String PARSE_CONTEXT_KEY_HANDLER_TYPE = "handler_type";
     public static final TypeReference<Map<String, Object>> MAP_STRING_OBJ_TYPE_REF = new TypeReference<>() {
     };
     @Autowired
@@ -302,6 +304,7 @@ public class TikaGrpcService extends TikaGrpc.TikaImplBase {
     }
 
     private void fetchAndParseImpl(FetchAndParseRequest request, StreamObserver<FetchAndParseReply> responseObserver) throws IOException {
+        log.debug("fetchAndParse request: {}", request);
         DefaultFetcherConfig fetcherConfig = fetcherRepository.findByFetcherId(request.getFetcherId());
         if (fetcherConfig == null) {
             throw new IOException("Could not find fetcher with ID " + request.getFetcherId());
@@ -320,12 +323,7 @@ public class TikaGrpcService extends TikaGrpc.TikaImplBase {
 
         Map<String, Object> addedMetadata = objectMapper.readValue(StringUtils.defaultIfBlank(request.getAddedMetadataJson(), "{}"), MAP_STRING_OBJ_TYPE_REF);
 
-        ParseContext parseContext;
-        if (StringUtils.isNotBlank(request.getParseContextJson())) {
-            parseContext = objectMapper.readValue(request.getParseContextJson(), ParseContext.class);
-        } else {
-            parseContext = new ParseContext();
-        }
+        ParseContext parseContext = createParseContext(request);
         try {
             log.info("Beginning parse for fetchKey={} with fetcherId={}", request.getFetchKey(), request.getFetcherId());
             for (Map<String, Object> metadata : parseService.parseDocument(inputStream, parseContext)) {
@@ -342,6 +340,25 @@ public class TikaGrpcService extends TikaGrpc.TikaImplBase {
             builder.setErrorMessage(ExceptionUtils.getRootCauseMessage(e));
         }
         responseObserver.onNext(builder.build());
+    }
+
+    private ParseContext createParseContext(FetchAndParseRequest request) {
+        ParseContext ctx = new ParseContext();
+        try {
+            Map<String, Object> attrs = objectMapper.readValue(
+                    StringUtils.defaultIfBlank(request.getParseContextJson(), "{}"),
+                    MAP_STRING_OBJ_TYPE_REF);
+
+            String hVal = (String) attrs.getOrDefault(
+                    PARSE_CONTEXT_KEY_HANDLER_TYPE,
+                    "TEXT");
+
+            ctx.set(BasicContentHandlerFactory.HANDLER_TYPE.class,
+                    BasicContentHandlerFactory.parseHandlerType(hVal, BasicContentHandlerFactory.HANDLER_TYPE.TEXT));
+        } catch (Exception e) {
+            log.warn("Failed to process 'parse context' in request. Will use the default.", e);
+        }
+        return ctx;
     }
 
     private void putMetadataFields(Map<String, Object> metadata, Metadata.Builder metadataBuilder) throws JsonProcessingException {


### PR DESCRIPTION
Currently `tika-pipes` output is in "plain text". This change enables configuring the output type as other formats, e.g., "xml", or "html". The goal is to use structured output w/ Markdown conversion.

### Testing
- Build `tika-pipes` image
  - `DOCKER_ID=<some-name> PROJECT_NAME=tika-pipes RELEASE_IMAGE_TAG=<some-tag> mvn clean package`
- Run the newly built image. Attach a volume with the test file.  Make sure the path inside and outside the container is the same, for ease of testing:
  -  `docker run -p 9090:9090 -v <absolute-path-to-the-test-dir>:<absolute-path-to-the-test-dir>  <some-name>/tika-pipes:<some-tag>
- Run `FileSystemFetcherCli` w/o passing a handler type argument:
  - `java -Dorg.slf4j.simpleLogger.defaultLogLevel=info -cp <classpath-with-necessary-jars>  org.apache.tika.pipes.cli.filesystem.FileSystemFetcherCli --base-directory <absolute-path-to-the-test-dir> --grpcHost localhost --grpcPort 9090`
- Run `FileSystemFetcherCli` w/ a handler type argument (some options are `TEXT`, `HTML`, `XML`):
  - `java -Dorg.slf4j.simpleLogger.defaultLogLevel=info -cp <classpath-with-necessary-jars>  org.apache.tika.pipes.cli.filesystem.FileSystemFetcherCli --base-directory <absolute-path-to-the-test-dir> --grpcHost localhost --grpcPort 9090 --handler-type HTML`