### PR TITLE
[ENG 6964] Add workflow to register `tika-pipes` image

### DIFF
--- a/.github/workflows/maven-publish-atolio.yml
+++ b/.github/workflows/maven-publish-atolio.yml
@@ -1,0 +1,57 @@
+name: Publish to Atolio Container Registries
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag prefix to build'
+        required: true
+
+env:
+  IMAGE_TAG: ${{ inputs.tag }}-${{ github.sha }}
+  AWS_ACCOUNT: 860511968828 # "Internal Tools" account
+  AWS_REGION: us-west-2
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DOGFOOD_DEPLOY_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DOGFOOD_DEPLOY_SECRET_ACCESS_KEY }}
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml -DskipTests=true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to AWS ECR
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.AWS_ACCOUNT }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+        username: ${{ env.AWS_ACCESS_KEY_ID }}
+        password: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: ./target/tika-docker
+        file: ./target/tika-docker/Dockerfile
+        push: true
+        tags: atolio/tika:${{ env.IMAGE_TAG }}
+


### PR DESCRIPTION
This workflow deploys `tika-pipes` image to "internal tools" ECR.

Requires the following secrets to be defined at org-level:
- `AWS_DOGFOOD_DEPLOY_ACCESS_KEY_ID`
- `AWS_DOGFOOD_DEPLOY_SECRET_ACCESS_KEY`

Not tested. May require some tweaks.