### PR TITLE
ENG-7220 Use correct numThreads variable in Dockerfile entrypoint

### DIFF
--- a/tika-pipes-grpc/docker-build/start-tika-grpc.sh
+++ b/tika-pipes-grpc/docker-build/start-tika-grpc.sh
@@ -15,7 +15,7 @@ exec java \
   -Dgrpc.server.port=9090 \
   "-Dgrpc.server.max-inbound-message-size=${TIKA_PIPES_MAX_INBOUND_MESSAGE_SIZE}" \
   "-Dgrpc.server.max-outbound-message-size=${TIKA_PIPES_MAX_INBOUND_MESSAGE_SIZE}" \
-  "-Dgrpc.server.numThreads=${TIKA_PIPES_MAX_INBOUND_MESSAGE_SIZE}" \
+  "-Dgrpc.server.numThreads=${TIKA_PIPES_GRPC_NUM_THREADS}" \
   "-Dlog4j.configurationFile=/tika/config/log4j2.xml" \
   --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
   --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED \


### PR DESCRIPTION
Previously this was set to > 1,000,000, as it was using the variable for max message size. This is a lot of threads!

It'll also tell us if tika-pipes is correctly cleaning up threads or not once we deploy this.