### PR TITLE
Fix environment variables in startup

### DIFF
--- a/tika-pipes-grpc/docker-build/start-tika-grpc.sh
+++ b/tika-pipes-grpc/docker-build/start-tika-grpc.sh
@@ -14,7 +14,7 @@ echo "${TIKA_PIPES_GRPC_NUM_THREADS}"
 exec java \
   -Dgrpc.server.port=9090 \
   "-Dgrpc.server.max-inbound-message-size=${TIKA_PIPES_MAX_INBOUND_MESSAGE_SIZE}" \
-  "-Dgrpc.server.max-outbound-message-size=${TIKA_PIPES_MAX_INBOUND_MESSAGE_SIZE}" \
+  "-Dgrpc.server.max-outbound-message-size=${TIKA_PIPES_MAX_OUTBOUND_MESSAGE_SIZE}" \
   "-Dgrpc.server.numThreads=${TIKA_PIPES_GRPC_NUM_THREADS}" \
   "-Dlog4j.configurationFile=/tika/config/log4j2.xml" \
   --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \

--- a/tika-pipes-grpc/src/main/resources/application.yaml
+++ b/tika-pipes-grpc/src/main/resources/application.yaml
@@ -5,8 +5,8 @@ grpc:
   server:
     numThreads: 4
     port: 9090
-    max-inbound-message-size: 1600777216 # 1600MB
-    max-outbound-message-size: 1600777216 # 1600MB
+    max-inbound-message-size: 104857600 # 100MB
+    max-outbound-message-size: 104857600 # 100MB
     health:
       enabled: false
 ignite:


### PR DESCRIPTION
* Outbound message size was using inbound msg size parameter
* application.yaml max sizes match Dockerfile. 1600mb previously documented was too high?