### PR TITLE
Support  local MinIO addressing, which requires Path-Style access rat…

### DIFF
--- a/tika-pipes-fetchers/tika-fetcher-s3/src/main/java/org/apache/tika/pipes/fetchers/s3/S3ClientManager.java
+++ b/tika-pipes-fetchers/tika-fetcher-s3/src/main/java/org/apache/tika/pipes/fetchers/s3/S3ClientManager.java
@@ -61,6 +61,10 @@ public class S3ClientManager {
             s3ClientBuilder.endpointOverride(URI.create(s3FetcherConfig.getEndpointOverride()));
         }
 
+        if (s3FetcherConfig.isPathStyleAccessEnabled()) {
+            s3ClientBuilder.forcePathStyle(true);
+        }
+
         return s3ClientBuilder.build();
     }
 


### PR DESCRIPTION
The S3FetcherConfig already exposes pathStyleAccessEnabled, but
  S3ClientManager.initialize() never reads it ,  so the flag silently
  no-ops and the AWS SDK v2 client falls back to its default,
  virtual-hosted-style addressing (bucket.host:port/key).

  Virtual-hosted style requires per-bucket DNS, which doesn't work
  against non-AWS S3-compatible endpoints like MinIO without wildcard
  DNS gymnastics. Path-style (host:port/bucket/key) is the standard
  addressing mode for these.

  This PR wires the flag into the builder via S3ClientBuilder
  .forcePathStyle(true) when set. Behavior is unchanged for AWS
  (flag defaults to false → virtual-hosted preserved).

  Unblocks atolio/lumen's local Tilt dev environment, which i want to use to 
  run MinIO as the assets/shared bucket and depends on docex
  forwarding pathStyleAccessEnabled=true through the FetcherConfig
  JSON.
